### PR TITLE
Switch to yargs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,9 @@
         "react-scripts": "4.0.1",
         "web-vitals": "^0.2.4",
         "yargs-parser": "^18.1.3"
+      },
+      "devDependencies": {
+        "cross-env": "^7.0.3"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -5583,6 +5586,24 @@
         "ripemd160": "^2.0.0",
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
+      }
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
       }
     },
     "node_modules/cross-spawn": {
@@ -25543,6 +25564,15 @@
         "ripemd160": "^2.0.0",
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
+      }
+    },
+    "cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.1"
       }
     },
     "cross-spawn": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "react": "^17.0.1",
         "react-dom": "^17.0.1",
         "react-scripts": "4.0.1",
-        "web-vitals": "^0.2.4"
+        "web-vitals": "^0.2.4",
+        "yargs-parser": "^18.1.3"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
         "@testing-library/jest-dom": "^5.11.9",
         "@testing-library/react": "^11.2.3",
         "@testing-library/user-event": "^12.6.2",
-        "minimist": "^1.2.5",
         "react": "^17.0.1",
         "react-dom": "^17.0.1",
         "react-scripts": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "build": "react-scripts build",
+    "build": "cross-env CI=false react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },
@@ -35,5 +35,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "cross-env": "^7.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-scripts": "4.0.1",
-    "web-vitals": "^0.2.4"
+    "web-vitals": "^0.2.4",
+    "yargs-parser": "^18.1.3"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "@testing-library/jest-dom": "^5.11.9",
     "@testing-library/react": "^11.2.3",
     "@testing-library/user-event": "^12.6.2",
-    "minimist": "^1.2.5",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-scripts": "4.0.1",

--- a/src/App.js
+++ b/src/App.js
@@ -6,13 +6,10 @@ import {
   getAvailableFlagsAsArray,
   getMatchingFlags,
   getParsedFlagsDescriptions,
+  getAliasesAsObject,
 } from "./git-command-parsing";
 
-import { snakeToCamel } from "./utils";
-
 // Gets the matching git command from the git-commands.js file, and formats the description using the arguments if needed.
-//TODO: Get the list of boolean flags from the commands file, and make it command specific.
-//TODO: Also add a description of the flags.
 
 function getGitCommand(inputCommand) {
   // Get the command name and check if it exists
@@ -31,13 +28,8 @@ function getGitCommand(inputCommand) {
 
   // These arrays exist so they can be used with minimist
   const availableFlagsAsArrays = getAvailableFlagsAsArray(availableFlags);
-  const aliasesObject = availableFlags.reduce((flagsList, flag) => {
-    if (flag.aliases) {
-      flagsList[snakeToCamel(flag.name)] = flag.aliases;
-    }
-    return flagsList;
-  }, {});
-  console.log(aliasesObject);
+  const aliasesObject = getAliasesAsObject(availableFlags);
+
   // Parse the arguments
   const parsedArgs = parser(inputCommand, {
     boolean: availableFlagsAsArrays.booleanFlagsArray,

--- a/src/App.js
+++ b/src/App.js
@@ -1,3 +1,4 @@
+import parser from "yargs-parser";
 import { useState } from "react";
 import "./App.css";
 import gitCommands from "./git-commands";
@@ -6,7 +7,6 @@ import {
   getMatchingFlags,
   getParsedFlagsDescriptions,
 } from "./git-command-parsing";
-const parseArgs = require("minimist");
 
 // Gets the matching git command from the git-commands.js file, and formats the description using the arguments if needed.
 //TODO: Get the list of boolean flags from the commands file, and make it command specific.
@@ -31,7 +31,7 @@ function getGitCommand(inputCommand) {
   const availableFlagsAsArrays = getAvailableFlagsAsArray(availableFlags);
 
   // Parse the arguments
-  const parsedArgs = parseArgs(inputCommand.split(" "), {
+  const parsedArgs = parser(inputCommand, {
     boolean: availableFlagsAsArrays.booleanFlagsArray,
     string: availableFlagsAsArrays.stringFlagsArray,
   });

--- a/src/App.js
+++ b/src/App.js
@@ -8,6 +8,8 @@ import {
   getParsedFlagsDescriptions,
 } from "./git-command-parsing";
 
+import { snakeToCamel } from "./utils";
+
 // Gets the matching git command from the git-commands.js file, and formats the description using the arguments if needed.
 //TODO: Get the list of boolean flags from the commands file, and make it command specific.
 //TODO: Also add a description of the flags.
@@ -29,13 +31,19 @@ function getGitCommand(inputCommand) {
 
   // These arrays exist so they can be used with minimist
   const availableFlagsAsArrays = getAvailableFlagsAsArray(availableFlags);
-
+  const aliasesObject = availableFlags.reduce((flagsList, flag) => {
+    if (flag.aliases) {
+      flagsList[snakeToCamel(flag.name)] = flag.aliases;
+    }
+    return flagsList;
+  }, {});
+  console.log(aliasesObject);
   // Parse the arguments
   const parsedArgs = parser(inputCommand, {
     boolean: availableFlagsAsArrays.booleanFlagsArray,
     string: availableFlagsAsArrays.stringFlagsArray,
+    alias: aliasesObject,
   });
-
   const matchingFlags = getMatchingFlags(availableFlags, parsedArgs);
 
   // Replace string tokens with arguments and add a list of flags descriptions if needed

--- a/src/git-command-parsing.js
+++ b/src/git-command-parsing.js
@@ -31,12 +31,7 @@ function getMatchingFlags(availableFlags, parsedArguments) {
       // TODO: add a check for duplicate
       return availableFlags.filter(
         (flag) =>
-          argumentValue &&
-          argumentKey !== "_" &&
-          ((flag.hasOwnProperty("aliases")
-            ? flag.aliases.includes(argumentKey)
-            : false) ||
-            flag.name === argumentKey)
+          argumentValue && argumentKey !== "_" && flag.name === argumentKey
       );
     }
   );

--- a/src/git-command-parsing.js
+++ b/src/git-command-parsing.js
@@ -1,3 +1,5 @@
+import { snakeToCamel } from "./utils";
+
 function getAvailableFlagsAsArray(availableFlagsObject) {
   const booleanFlagsArray = availableFlagsObject
     .filter((flag) => !flag.isString)
@@ -64,8 +66,17 @@ function getParsedFlagsDescriptions(flagsDescriptions, commandArguments) {
   });
 }
 
+function getAliasesAsObject(availableFlags) {
+  return availableFlags.reduce((flagsList, flag) => {
+    if (flag.aliases) {
+      flagsList[snakeToCamel(flag.name)] = flag.aliases;
+    }
+    return flagsList;
+  }, {});
+}
 export {
   getAvailableFlagsAsArray,
   getMatchingFlags,
   getParsedFlagsDescriptions,
+  getAliasesAsObject,
 };

--- a/src/git-command-parsing.js
+++ b/src/git-command-parsing.js
@@ -47,7 +47,6 @@ function getMatchingFlags(availableFlags, parsedArguments) {
 // Parse the flags descriptions if needed
 // TODO: Fix arguments between double quotes not working
 function getParsedFlagsDescriptions(flagsDescriptions, commandArguments) {
-  console.log(commandArguments);
   return flagsDescriptions.map((flag) => {
     if (flag.isString) {
       // Gets the matching string value for the current flag

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,6 @@
+const snakeToCamel = (str) =>
+  str.replace(/([-_][a-z])/g, (group) =>
+    group.toUpperCase().replace("-", "").replace("_", "")
+  );
+
+export { snakeToCamel };


### PR DESCRIPTION
Switched the parsing library from minimist to yargs-parser because it was simpler to use for that specific use-case. It handles the aliases logic itself, making the code way more readable, and also fixes the issue with flag values between quotes.