### PR TITLE
Implement git log, pull and status

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,9 @@ So far, only a few commands are supported, with a few flags:
   * push
   * rebase
   * diff
-
+  * log
+  * pull
+  * status
 
 ## Contribute
 As I stated above, pull requests, bug reports and feature requests are very much appreciated. This is a big project for me, and any help would be truly appreciated! I setup a couple of templates in the issues section if you want to contribute. I don't feel like adding a code of conduct, I only expect contributors to be respectful to each other.

--- a/src/git-commands.ts
+++ b/src/git-commands.ts
@@ -166,6 +166,23 @@ const gitCommands = {
         },
       ]
     },
+    {
+      name: 'pull',
+      description: 'Merge changes from a remote repository into the current branch',
+      flags: [
+        {
+          name: 'commit',
+          description: 'Commits the result of the merge.',
+          isString: false,
+        },
+        {
+          name: 'edit',
+          aliases: ['e'],
+          description: 'Opens an editor to modify the auto-generated merge message before commiting to further explain the merge.',
+          isString: false,
+        },
+      ]
+    },
   ],
 }
 

--- a/src/git-commands.ts
+++ b/src/git-commands.ts
@@ -140,6 +140,32 @@ const gitCommands = {
         },
       ]
     },
+    {
+      name: 'log',
+      description: 'Lists commits and its information in reverse chronological order',
+      flags: [
+        {
+          name: 'source',
+          description: 'Print out the ref information of each commit (Such as tags/branches).',
+          isString: false,
+        },
+        {
+          name: 'log-size',
+          description: 'Include the lenght of each commit message in bytes.',
+          isString: false,
+        },
+        {
+          name: 'abbrev-commit',
+          description: 'Shows a unique object prefix that substitutes the full 40-byte hexadecimal commit object name',
+          isString: false,
+        },
+        {
+          name: 'oneline',
+          description: 'Displays the information of each commit in only one line and abbreviates the object\'s name (The same way as --abbrev-commit).',
+          isString: false,
+        },
+      ]
+    },
   ],
 }
 

--- a/src/git-commands.ts
+++ b/src/git-commands.ts
@@ -183,6 +183,29 @@ const gitCommands = {
         },
       ]
     },
+    {
+      name: 'status',
+      description: 'Displays the paths that have differences between the index file and staged, tracked or untracked files',
+      flags: [
+        {
+          name: 'short',
+          aliases: ['s'],
+          description: 'Outputs the status in the short format.',
+          isString: false,
+        },
+        {
+          name: 'long',
+          description: 'Outputs the status in the long format (Default).',
+          isString: false,
+        },
+        {
+          name: 'verbose',
+          aliases: ['v'],
+          description: 'Shows the textual changes that are staged to be commited as well as the name of the files (The same way as git diff --cached).',
+          isString: false,
+        },
+      ]
+    },
   ],
 }
 


### PR DESCRIPTION
Adds the git log, pull and status with some of its flags (and updates the command list in the README):

- Git log: source, log-size, abbrev-commit and oneline.
- Git pull: commit and edit.
- Git status: short, long and verbose.

All descriptions based on the [git documentation](https://git-scm.com/docs).